### PR TITLE
[Update] Refactor PostalTradeAddressModel to use Lombok annotation for builder pattern.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	compile("org.springframework.boot:spring-boot-devtools")
 	compile("io.springfox:springfox-swagger2:2.8.0")
 	compile("io.springfox:springfox-swagger-ui:2.8.0")
+	compile("org.projectlombok:lombok:1.16.20")
 
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }

--- a/src/main/java/th/ac/kmitl/it/soa/group3/model/supplychaintradetransaction/PostalTradeAddressModel.java
+++ b/src/main/java/th/ac/kmitl/it/soa/group3/model/supplychaintradetransaction/PostalTradeAddressModel.java
@@ -1,5 +1,8 @@
 package th.ac.kmitl.it.soa.group3.model.supplychaintradetransaction;
 
+import lombok.Builder;
+
+@Builder
 public class PostalTradeAddressModel {
 
     public String postCode;
@@ -15,106 +18,4 @@ public class PostalTradeAddressModel {
     public String countryID;
     public String countrySubDivisionID;
     public String buildingNumber;
-
-    private PostalTradeAddressModel(Builder builder) {
-        this.postCode = builder.postCode;
-        this.buildingName = builder.buildingName;
-        this.houseNumber = builder.houseNumber;
-        this.suiteNumber = builder.suiteNumber;
-        this.soi = builder.soi;
-        this.village = builder.village;
-        this.moo = builder.moo;
-        this.streetName = builder.streetName;
-        this.cityName = builder.cityName;
-        this.citySubDivisionName = builder.citySubDivisionName;
-        this.countryID = builder.countryID;
-        this.countrySubDivisionID = builder.countrySubDivisionID;
-        this.buildingNumber = builder.buildingNumber;
-    }
-
-    public static class Builder {
-
-        private String postCode;
-        private String buildingName;
-        private String houseNumber;
-        private String suiteNumber;
-        private String soi;
-        private String village;
-        private String moo;
-        private String streetName;
-        private String cityName;
-        private String citySubDivisionName;
-        private String countryID;
-        private String countrySubDivisionID;
-        private String buildingNumber;
-
-        public Builder withPostCode(String postCode) {
-            this.postCode = postCode;
-            return this;
-        }
-
-        public Builder withBuildingName(String buildingName) {
-            this.buildingName = buildingName;
-            return this;
-        }
-
-        public Builder withHouseNumber(String houseNumber) {
-            this.houseNumber = houseNumber;
-            return this;
-        }
-
-        public Builder withSuiteNumber(String suiteNumber) {
-            this.suiteNumber = suiteNumber;
-            return this;
-        }
-
-        public Builder withSoi(String soi) {
-            this.soi = soi;
-            return this;
-        }
-
-        public Builder withVillage(String village) {
-            this.village = village;
-            return this;
-        }
-
-        public Builder withMoo(String moo) {
-            this.moo = moo;
-            return this;
-        }
-
-        public Builder withStreetName(String streetName) {
-            this.streetName = streetName;
-            return this;
-        }
-
-        public Builder withCityName(String cityName) {
-            this.cityName = cityName;
-            return this;
-        }
-
-        public Builder withCitySubDivisionName(String citySubDivisionName) {
-            this.citySubDivisionName = citySubDivisionName;
-            return this;
-        }
-
-        public Builder withCountryID(String countryID) {
-            this.countryID = countryID;
-            return this;
-        }
-
-        public Builder withCountrySubDivisionID(String countrySubDivisionID) {
-            this.countrySubDivisionID = countrySubDivisionID;
-            return this;
-        }
-
-        public Builder withBuildingNumber(String buildingNumber) {
-            this.buildingNumber = buildingNumber;
-            return this;
-        }
-
-        public PostalTradeAddressModel build() {
-            return new PostalTradeAddressModel(this);
-        }
-    }
 }

--- a/src/main/java/th/ac/kmitl/it/soa/group3/model/supplychaintradetransaction/PostalTradeAddressModel.java
+++ b/src/main/java/th/ac/kmitl/it/soa/group3/model/supplychaintradetransaction/PostalTradeAddressModel.java
@@ -2,7 +2,7 @@ package th.ac.kmitl.it.soa.group3.model.supplychaintradetransaction;
 
 import lombok.Builder;
 
-@Builder
+@Builder(builderClassName = "Builder")
 public class PostalTradeAddressModel {
 
     public String postCode;

--- a/src/test/java/th/ac/kmitl/it/soa/group3/model/supplychaintradetransaction/PostalTradeAddressModelTest.java
+++ b/src/test/java/th/ac/kmitl/it/soa/group3/model/supplychaintradetransaction/PostalTradeAddressModelTest.java
@@ -23,19 +23,19 @@ public class PostalTradeAddressModelTest {
     public void itShouldGetAllInfoByGetter() {
         PostalTradeAddressModel.Builder builder = new PostalTradeAddressModel.Builder();
         PostalTradeAddressModel postalTradeAddressModel = builder
-                .withPostCode(this.postCode)
-                .withBuildingName(this.buildingName)
-                .withHouseNumber(this.houseNumber)
-                .withSuiteNumber(this.suiteNumber)
-                .withSoi(this.soi)
-                .withVillage(this.village)
-                .withMoo(this.moo)
-                .withStreetName(this.streetName)
-                .withCityName(this.cityName)
-                .withCitySubDivisionName(this.citySubDivisionName)
-                .withCountryID(this.countryID)
-                .withCountrySubDivisionID(this.countrySubDivisionID)
-                .withBuildingNumber(this.buildingNumber)
+                .postCode(this.postCode)
+                .buildingName(this.buildingName)
+                .houseNumber(this.houseNumber)
+                .suiteNumber(this.suiteNumber)
+                .soi(this.soi)
+                .village(this.village)
+                .moo(this.moo)
+                .streetName(this.streetName)
+                .cityName(this.cityName)
+                .citySubDivisionName(this.citySubDivisionName)
+                .countryID(this.countryID)
+                .countrySubDivisionID(this.countrySubDivisionID)
+                .buildingNumber(this.buildingNumber)
                 .build();
 
         assertEquals(this.postCode, postalTradeAddressModel.postCode);


### PR DESCRIPTION
- Add Lombok to build.gradle.
- Remove boilerplate code for builder pattern.
- Add lombok annotation for builder pattern.
- Change Test parameter to match lombok default name.
- This is to provide example of how to use lombok for builder pattern as suggested by @tumit 