### PR TITLE
[Update] Implement Jackson XML to ExchangedDocument and create controller with unit test

### DIFF
--- a/src/main/java/th/ac/kmitl/it/soa/group3/controller/ExchangedDocumentController.java
+++ b/src/main/java/th/ac/kmitl/it/soa/group3/controller/ExchangedDocumentController.java
@@ -1,0 +1,35 @@
+package th.ac.kmitl.it.soa.group3.controller;
+
+import io.swagger.annotations.Api;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import th.ac.kmitl.it.soa.group3.model.TypeCode;
+import java.sql.Timestamp;
+import th.ac.kmitl.it.soa.group3.model.exchangeddocument.ExchangedDocumentModel;
+import th.ac.kmitl.it.soa.group3.model.exchangeddocument.IncludedNoteModel;
+
+@RestController
+@Api(value = "ExchangedDocument XML", description = "This is ExchangedDocument XML")
+public class ExchangedDocumentController {
+
+    @GetMapping(value = "/exchangeddoc")
+    public ExchangedDocumentModel exchangedDocumentXML() {
+        IncludedNoteModel includedNote = IncludedNoteModel.builder()
+                .subject("หมายเหตุ")
+                .content("ค่าบริการเพิ่มเติม")
+                .build();
+        ExchangedDocumentModel exchangedDocument = ExchangedDocumentModel.builder()
+                .id("RDTIV0575526000058001")
+                .name(TypeCode.TAX_INVOICE.getDescription())
+                .typeCode(TypeCode.TAX_INVOICE.getTypeCode())
+                .issueDateTime(new Timestamp(System.currentTimeMillis()))
+                .purpose("คำนวณราคาค่าบริการผิดพลาดสูงกว่าที่เป็นจริง")
+                .purposeCode("DCNS03")
+                .globalID("ABCDEFGHIJKLMNOPQRST123456789012345")
+                .creationDateTime(new Timestamp(System.currentTimeMillis()))
+                .includedNote(includedNote)
+                .build();
+
+        return exchangedDocument;
+    }
+}

--- a/src/main/java/th/ac/kmitl/it/soa/group3/model/exchangeddocument/ExchangedDocumentModel.java
+++ b/src/main/java/th/ac/kmitl/it/soa/group3/model/exchangeddocument/ExchangedDocumentModel.java
@@ -1,18 +1,38 @@
 package th.ac.kmitl.it.soa.group3.model.exchangeddocument;
 
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import lombok.Builder;
 import java.sql.Timestamp;
 
+@JacksonXmlRootElement(localName = "rsm:ExchangedDocument")
 @Builder(builderClassName = "Builder")
 public class ExchangedDocumentModel {
 
+    @JacksonXmlProperty(localName = "ram:ID")
     public String id;
+
+    @JacksonXmlProperty(localName = "ram:Name")
     public String name;
+
+    @JacksonXmlProperty(localName = "ram:TypeCode")
     public String typeCode;
+
+    @JacksonXmlProperty(localName = "ram:IssueDateTime")
     public Timestamp issueDateTime;
+
+    @JacksonXmlProperty(localName = "ram:Purpose")
     public String purpose;
+
+    @JacksonXmlProperty(localName = "ram:PurposeCode")
     public String purposeCode;
+
+    @JacksonXmlProperty(localName = "ram:GlobalID")
     public String globalID;
+
+    @JacksonXmlProperty(localName = "ram:CreationDateTime")
     public Timestamp creationDateTime;
+
+    @JacksonXmlProperty(localName = "ram:IncludedNote")
     public IncludedNoteModel includedNote;
 }

--- a/src/main/java/th/ac/kmitl/it/soa/group3/model/exchangeddocument/IncludedNoteModel.java
+++ b/src/main/java/th/ac/kmitl/it/soa/group3/model/exchangeddocument/IncludedNoteModel.java
@@ -1,11 +1,16 @@
 package th.ac.kmitl.it.soa.group3.model.exchangeddocument;
 
 import lombok.Builder;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
+@JacksonXmlRootElement(localName = "ram:IncludedNote")
 @Builder(builderClassName = "Builder")
 public class IncludedNoteModel {
 
+    @JacksonXmlProperty(localName = "ram:Subject")
     public String subject;
-    public String content;
 
+    @JacksonXmlProperty(localName = "ram:Content")
+    public String content;
 }

--- a/src/test/java/th/ac/kmitl/it/soa/group3/controller/ExchangedDocumentControllerTest.java
+++ b/src/test/java/th/ac/kmitl/it/soa/group3/controller/ExchangedDocumentControllerTest.java
@@ -1,0 +1,33 @@
+package th.ac.kmitl.it.soa.group3.controller;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ExchangedDocumentControllerTest {
+
+    static private MockMvc mockMvc;
+
+    @InjectMocks
+    private static ExchangedDocumentController exchangedDocumentController = new ExchangedDocumentController();
+
+    @BeforeAll
+    static void init() {
+        mockMvc = MockMvcBuilders.standaloneSetup(exchangedDocumentController).build();
+    }
+
+    @Test
+    void shouldRequestAndGetXmlResponse() throws Exception {
+        mockMvc.perform(get("/exchangeddoc")
+                .contentType(MediaType.APPLICATION_XML))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML));
+    }
+}


### PR DESCRIPTION
Implement issue #48  with the following:

[Add] ExchangedDocumentModel to demonstrate how to use Jackson XML to annotate class property
[Add] ExchangedDocumentController to enabled get request to see the XML response